### PR TITLE
Fix audio crackling and thread synchronization

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,8 @@ use std::thread;
 use std::time::{Duration, SystemTime};
 use midir::Ignore;
 use midir::MidiInput;
+use eframe::egui;
+use std::sync::atomic::{AtomicU8, Ordering};
 
 const ATTACK_MS: u128 = 2000;
 const RELEASE_MS: u128 = 2000;
@@ -17,6 +19,27 @@ const RELEASE_MS: u128 = 2000;
 const WAVE_TYPE_SINE: u8 = 0;
 const WAVE_TYPE_SAW: u8 = 1;
 const WAVE_TYPE_SQUARE: u8 = 2;
+
+const DEFAULT_ATTACK: u16 = 10;
+const DEFAULT_DECAY: u16 = 600;
+const DEFAULT_SUSTAIN: f32 = 0.2;
+const DEFAULT_RELEASE: u16 = 800;
+
+const SEMITONE_MIN: i32 = -36; // 3 octaves down
+const SEMITONE_MAX: i32 = 36;  // 3 octaves up
+
+const CENTS_MIN: f32 = -100.0;
+const CENTS_MAX: f32 = 100.0;
+
+const VOLUME_MIN: f32 = 0.0;
+const VOLUME_MAX: f32 = 1.0;
+
+const SAMPLE_RATE: u32 = 48000; // Higher sample rate for better quality
+const ANTI_POP_SAMPLES: usize = 128; // Anti-pop buffer size
+
+const FILTER_MODE_LOW: u8 = 0;
+const FILTER_MODE_BAND: u8 = 1;
+const FILTER_MODE_HIGH: u8 = 2;
 
 struct NoteData {
     note: std::thread::JoinHandle<()>,
@@ -47,8 +70,11 @@ struct WavetableOscillator {
     sustain: f32,
     release: u16,
     shared: Arc<Mutex<f32>>,
+    filter: StateVariableFilter,
+    filter_cutoff: f32,
+    filter_resonance: f32,
+    filter_mode: u8,
 }
-
 
 impl WavetableOscillator {
     fn new(sample_rate: u32, wave_table: Vec<f32>, shared: Arc<Mutex<f32>>) -> WavetableOscillator {
@@ -67,6 +93,10 @@ impl WavetableOscillator {
             sustain: 0.0,
             release: 0,
             shared: shared,
+            filter: StateVariableFilter::new(sample_rate),
+            filter_cutoff: 1000.0,
+            filter_resonance: 0.5,
+            filter_mode: FILTER_MODE_LOW,
         }
     }
 
@@ -109,7 +139,7 @@ impl WavetableOscillator {
                     // Attack amplitude envelope.
                     if self.attack > 0 {
                         if elapsed.as_millis() < self.attack as u128  {
-                            amp *= (elapsed.as_millis() as f32 / self.attack as f32);
+                            amp *= elapsed.as_millis() as f32 / self.attack as f32;
                         }
                     }
                     if elapsed.as_millis() > self.attack as u128  {
@@ -160,18 +190,57 @@ impl WavetableOscillator {
         return amp;
     }
 
+    fn set_filter_cutoff(&mut self, cutoff: f32) {
+        self.filter_cutoff = cutoff.clamp(MIN_FREQ, MAX_FREQ);
+        self.filter.set_cutoff(self.filter_cutoff);
+    }
+
+    fn set_filter_resonance(&mut self, resonance: f32) {
+        self.filter_resonance = resonance.clamp(MIN_RESONANCE, MAX_RESONANCE);
+        self.filter.set_resonance(self.filter_resonance);
+    }
+
+    fn set_filter_mode(&mut self, mode: u8) {
+        self.filter_mode = mode;
+        self.filter.set_mode(mode);
+    }
+
     fn get_sample(&mut self) -> f32 {
-        // Check for shared mutex amplitude, when it reaches 0,
-        // set note off and trigger decay envelope.
+        // Apply anti-pop envelope when starting or stopping
         if self.note_on {
             if *self.shared.lock().unwrap() == 0.0 {
                 self.set_note_on(false);
             }
         }
+        
         let sample = self.lerp();
         self.index += self.index_increment;
         self.index %= self.wave_table.len() as f32;
-        return self.get_amplitude() * sample;
+        
+        // Get the main amplitude envelope
+        let amp = self.get_amplitude();
+        
+        // Apply gentle anti-pop ramp at the very start and end
+        let elapsed_samples = self.note_on_time.elapsed().unwrap().as_secs_f32() * self.sample_rate as f32;
+        let start_ramp = if elapsed_samples < ANTI_POP_SAMPLES as f32 {
+            elapsed_samples / ANTI_POP_SAMPLES as f32
+        } else {
+            1.0
+        };
+        
+        let raw_sample = if !self.note_on {
+            let release_samples = self.note_off_time.elapsed().unwrap().as_secs_f32() * self.sample_rate as f32;
+            if release_samples < ANTI_POP_SAMPLES as f32 {
+                amp * sample * (1.0 - release_samples / ANTI_POP_SAMPLES as f32) * start_ramp
+            } else {
+                amp * sample * start_ramp
+            }
+        } else {
+            amp * sample * start_ramp
+        };
+
+        // Process through filter
+        self.filter.process(raw_sample)
     }
 
     fn lerp(&mut self) -> f32 {
@@ -181,7 +250,8 @@ impl WavetableOscillator {
         let next_index_weight = self.index - truncated_index as f32;
         let truncated_index_weight = 1.0 - next_index_weight;
 
-        return (truncated_index_weight * self.wave_table[truncated_index] + next_index_weight * self.wave_table[next_index]);
+        truncated_index_weight * self.wave_table[truncated_index] + 
+            next_index_weight * self.wave_table[next_index]
     }
 }
 
@@ -211,6 +281,72 @@ impl Source for WavetableOscillator {
     }
 }
 
+const MIN_FREQ: f32 = 20.0;
+const MAX_FREQ: f32 = 20000.0;
+const MIN_RESONANCE: f32 = 0.0;
+const MAX_RESONANCE: f32 = 1.0;
+
+struct StateVariableFilter {
+    cutoff: f32,
+    resonance: f32,
+    sample_rate: f32,
+    low_pass: f32,
+    band_pass: f32,
+    high_pass: f32,
+    last_input: f32,
+    mode: u8,
+}
+
+impl StateVariableFilter {
+    fn new(sample_rate: u32) -> Self {
+        Self {
+            cutoff: 1000.0,  // Default cutoff frequency
+            resonance: 0.5,   // Default resonance
+            sample_rate: sample_rate as f32,
+            low_pass: 0.0,
+            band_pass: 0.0,
+            high_pass: 0.0,
+            last_input: 0.0,
+            mode: FILTER_MODE_LOW,
+        }
+    }
+
+    fn set_cutoff(&mut self, cutoff: f32) {
+        self.cutoff = cutoff.clamp(MIN_FREQ, MAX_FREQ);
+    }
+
+    fn set_resonance(&mut self, resonance: f32) {
+        self.resonance = resonance.clamp(MIN_RESONANCE, MAX_RESONANCE);
+    }
+
+    fn set_mode(&mut self, mode: u8) {
+        self.mode = mode;
+    }
+
+    fn process(&mut self, input: f32) -> f32 {
+        // Calculate filter coefficients
+        let f = 2.0 * std::f32::consts::PI * self.cutoff / self.sample_rate;
+        let q = 1.0 - self.resonance;  // Higher resonance = lower damping
+        
+        // Clamp coefficients for stability
+        let f = f.min(0.99);
+        let q = q.max(0.01);
+
+        // Process one sample
+        self.high_pass = input - self.low_pass - q * self.band_pass;
+        self.band_pass += f * self.high_pass;
+        self.low_pass += f * self.band_pass;
+
+        // Return output based on selected mode
+        match self.mode {
+            FILTER_MODE_LOW => self.low_pass,
+            FILTER_MODE_BAND => self.band_pass,
+            FILTER_MODE_HIGH => self.high_pass,
+            _ => self.low_pass,
+        }
+    }
+}
+
 struct WtVoice {
     shared: Arc<Mutex<f32>>,
     wt_osc: WavetableOscillator,
@@ -224,33 +360,357 @@ struct WtVoice {
 }
 
 impl WtVoice {
-    fn new(shared: Arc<Mutex<f32>>, midi_port: midir::MidiInputPort, frequency: f32, amplitude: f32) {
+    fn new(_shared: Arc<Mutex<f32>>, _midi_port: midir::MidiInputPort, _frequency: f32, _amplitude: f32) {
+        // Implementation pending
+    }
+}
 
+#[derive(Clone)]
+struct VoiceSettings {
+    enabled: Arc<Mutex<bool>>,
+    wave_type: Arc<AtomicU8>,
+    semitones: Arc<Mutex<i32>>,
+    cents: Arc<Mutex<f32>>,
+    volume: Arc<Mutex<f32>>,
+}
+
+impl VoiceSettings {
+    fn new(wave_type: u8, semitones: i32) -> Self {
+        Self {
+            enabled: Arc::new(Mutex::new(true)),
+            wave_type: Arc::new(AtomicU8::new(wave_type)),
+            semitones: Arc::new(Mutex::new(semitones)),
+            cents: Arc::new(Mutex::new(0.0)),
+            volume: Arc::new(Mutex::new(1.0)),
+        }
+    }
+
+    fn is_enabled(&self) -> bool {
+        *self.enabled.lock().unwrap()
+    }
+
+    fn set_enabled(&self, value: bool) {
+        *self.enabled.lock().unwrap() = value;
+    }
+
+    fn get_cents(&self) -> f32 {
+        *self.cents.lock().unwrap()
+    }
+
+    fn set_cents(&self, value: f32) {
+        *self.cents.lock().unwrap() = value;
+    }
+
+    fn get_wave_type(&self) -> u8 {
+        self.wave_type.load(Ordering::Relaxed)
+    }
+
+    fn set_wave_type(&self, value: u8) {
+        self.wave_type.store(value, Ordering::Relaxed);
+    }
+
+    fn get_semitones(&self) -> i32 {
+        *self.semitones.lock().unwrap()
+    }
+
+    fn set_semitones(&self, value: i32) {
+        *self.semitones.lock().unwrap() = value;
+    }
+
+    fn get_volume(&self) -> f32 {
+        *self.volume.lock().unwrap()
+    }
+
+    fn set_volume(&self, value: f32) {
+        *self.volume.lock().unwrap() = value;
+    }
+}
+
+#[derive(Clone)]
+struct SynthSettings {
+    attack: Arc<Mutex<u16>>,
+    decay: Arc<Mutex<u16>>,
+    sustain: Arc<Mutex<f32>>,
+    release: Arc<Mutex<u16>>,
+    filter_cutoff: Arc<Mutex<f32>>,
+    filter_resonance: Arc<Mutex<f32>>,
+    filter_mode: Arc<AtomicU8>,
+    voice1: VoiceSettings,
+    voice2: VoiceSettings,
+    voice3: VoiceSettings,
+}
+
+impl Default for SynthSettings {
+    fn default() -> Self {
+        Self {
+            attack: Arc::new(Mutex::new(DEFAULT_ATTACK)),
+            decay: Arc::new(Mutex::new(DEFAULT_DECAY)),
+            sustain: Arc::new(Mutex::new(DEFAULT_SUSTAIN)),
+            release: Arc::new(Mutex::new(DEFAULT_RELEASE)),
+            filter_cutoff: Arc::new(Mutex::new(1000.0)),
+            filter_resonance: Arc::new(Mutex::new(0.5)),
+            filter_mode: Arc::new(AtomicU8::new(FILTER_MODE_LOW)),
+            voice1: VoiceSettings::new(WAVE_TYPE_SAW, 0),     // Default to saw, no transpose
+            voice2: VoiceSettings::new(WAVE_TYPE_SQUARE, -12), // Default to square, -1 octave
+            voice3: VoiceSettings::new(WAVE_TYPE_SINE, 12),   // Default to sine, +1 octave
+        }
+    }
+}
+
+impl SynthSettings {
+    fn get_attack(&self) -> u16 {
+        *self.attack.lock().unwrap()
+    }
+
+    fn get_decay(&self) -> u16 {
+        *self.decay.lock().unwrap()
+    }
+
+    fn get_sustain(&self) -> f32 {
+        *self.sustain.lock().unwrap()
+    }
+
+    fn get_release(&self) -> u16 {
+        *self.release.lock().unwrap()
+    }
+
+    fn set_attack(&self, value: u16) {
+        *self.attack.lock().unwrap() = value;
+    }
+
+    fn set_decay(&self, value: u16) {
+        *self.decay.lock().unwrap() = value;
+    }
+
+    fn set_sustain(&self, value: f32) {
+        *self.sustain.lock().unwrap() = value;
+    }
+
+    fn set_release(&self, value: u16) {
+        *self.release.lock().unwrap() = value;
+    }
+
+    fn get_filter_cutoff(&self) -> f32 {
+        *self.filter_cutoff.lock().unwrap()
+    }
+
+    fn get_filter_resonance(&self) -> f32 {
+        *self.filter_resonance.lock().unwrap()
+    }
+
+    fn set_filter_cutoff(&self, value: f32) {
+        *self.filter_cutoff.lock().unwrap() = value.clamp(MIN_FREQ, MAX_FREQ);
+    }
+
+    fn set_filter_resonance(&self, value: f32) {
+        *self.filter_resonance.lock().unwrap() = value.clamp(MIN_RESONANCE, MAX_RESONANCE);
+    }
+
+    fn get_filter_mode(&self) -> u8 {
+        self.filter_mode.load(Ordering::Relaxed)
+    }
+
+    fn set_filter_mode(&self, mode: u8) {
+        self.filter_mode.store(mode, Ordering::Relaxed);
+    }
+}
+
+struct SynthUI {
+    settings: SynthSettings,
+    midi_thread: Option<std::thread::JoinHandle<()>>,
+    settings_sender: mpsc::Sender<SynthSettings>,
+}
+
+impl SynthUI {
+    fn new(_cc: &eframe::CreationContext<'_>) -> Self {
+        let (settings_sender, settings_receiver) = mpsc::channel();
+        
+        // Start MIDI handling in a separate thread
+        let midi_thread = Some(std::thread::spawn(move || {
+            if let Err(err) = run(settings_receiver) {
+                println!("Error in MIDI thread: {}", err);
+            }
+        }));
+
+        Self {
+            settings: SynthSettings::default(),
+            midi_thread,
+            settings_sender,
+        }
+    }
+}
+
+impl eframe::App for SynthUI {
+    fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
+        egui::CentralPanel::default().show(ctx, |ui| {
+            ui.heading("Synthesizer Controls");
+            
+            // Helper function to create voice controls
+            let add_voice_controls = |ui: &mut egui::Ui, voice: &VoiceSettings, voice_name: &str| {
+                ui.group(|ui| {
+                    ui.horizontal(|ui| {
+                        ui.heading(voice_name);
+                        let mut enabled = voice.is_enabled();
+                        if ui.checkbox(&mut enabled, "Enabled").changed() {
+                            voice.set_enabled(enabled);
+                            let _ = self.settings_sender.send(self.settings.clone());
+                        }
+                    });
+
+                    if voice.is_enabled() {
+                        ui.horizontal(|ui| {
+                            ui.label("Volume:");
+                            let mut volume = voice.get_volume();
+                            if ui.add(egui::Slider::new(&mut volume, VOLUME_MIN..=VOLUME_MAX)
+                                .text("vol")).changed() {
+                                voice.set_volume(volume);
+                                let _ = self.settings_sender.send(self.settings.clone());
+                            }
+                        });
+
+                        ui.horizontal(|ui| {
+                            ui.label("Wave Type:");
+                            let mut current_wave = voice.get_wave_type();
+                            if ui.radio_value(&mut current_wave, WAVE_TYPE_SINE, "Sine").clicked() ||
+                               ui.radio_value(&mut current_wave, WAVE_TYPE_SAW, "Saw").clicked() ||
+                               ui.radio_value(&mut current_wave, WAVE_TYPE_SQUARE, "Square").clicked() {
+                                voice.set_wave_type(current_wave);
+                                let _ = self.settings_sender.send(self.settings.clone());
+                            }
+                        });
+                        
+                        ui.horizontal(|ui| {
+                            ui.label("Semitones:");
+                            let mut semitones = voice.get_semitones();
+                            if ui.add(egui::Slider::new(&mut semitones, SEMITONE_MIN..=SEMITONE_MAX)).changed() {
+                                voice.set_semitones(semitones);
+                                let _ = self.settings_sender.send(self.settings.clone());
+                            }
+                        });
+
+                        ui.horizontal(|ui| {
+                            ui.label("Cents:");
+                            let mut cents = voice.get_cents();
+                            if ui.add(egui::Slider::new(&mut cents, CENTS_MIN..=CENTS_MAX)).changed() {
+                                voice.set_cents(cents);
+                                let _ = self.settings_sender.send(self.settings.clone());
+                            }
+                        });
+                    }
+                });
+            };
+
+            add_voice_controls(ui, &self.settings.voice1, "Voice 1");
+            ui.add_space(10.0);
+            add_voice_controls(ui, &self.settings.voice2, "Voice 2");
+            ui.add_space(10.0);
+            add_voice_controls(ui, &self.settings.voice3, "Voice 3");
+            ui.add_space(10.0);
+
+            // Filter controls
+            ui.group(|ui| {
+                ui.heading("Filter");
+                
+                // Add filter mode selection
+                ui.horizontal(|ui| {
+                    ui.label("Mode:");
+                    let mut current_mode = self.settings.get_filter_mode();
+                    if ui.radio_value(&mut current_mode, FILTER_MODE_LOW, "Low Pass").clicked() ||
+                       ui.radio_value(&mut current_mode, FILTER_MODE_BAND, "Band Pass").clicked() ||
+                       ui.radio_value(&mut current_mode, FILTER_MODE_HIGH, "High Pass").clicked() {
+                        self.settings.set_filter_mode(current_mode);
+                        let _ = self.settings_sender.send(self.settings.clone());
+                    }
+                });
+
+                ui.horizontal(|ui| {
+                    ui.label("Cutoff:");
+                    let mut cutoff = self.settings.get_filter_cutoff();
+                    if ui.add(
+                        egui::Slider::new(&mut cutoff, MIN_FREQ..=MAX_FREQ)
+                            .logarithmic(true)
+                            .text("Hz")
+                    ).changed() {
+                        self.settings.set_filter_cutoff(cutoff);
+                        let _ = self.settings_sender.send(self.settings.clone());
+                    }
+                });
+                
+                ui.horizontal(|ui| {
+                    ui.label("Resonance:");
+                    let mut resonance = self.settings.get_filter_resonance();
+                    if ui.add(egui::Slider::new(&mut resonance, MIN_RESONANCE..=MAX_RESONANCE)).changed() {
+                        self.settings.set_filter_resonance(resonance);
+                        let _ = self.settings_sender.send(self.settings.clone());
+                    }
+                });
+            });
+
+            ui.add_space(10.0);
+
+            // ADSR controls
+            ui.group(|ui| {
+                ui.heading("Envelope");
+                ui.horizontal(|ui| {
+                    ui.label("Attack:");
+                    let mut attack = self.settings.get_attack();
+                    if ui.add(egui::Slider::new(&mut attack, 0..=2000).text("ms")).changed() {
+                        self.settings.set_attack(attack);
+                        let _ = self.settings_sender.send(self.settings.clone());
+                    }
+                });
+                
+                ui.horizontal(|ui| {
+                    ui.label("Decay:");
+                    let mut decay = self.settings.get_decay();
+                    if ui.add(egui::Slider::new(&mut decay, 0..=2000).text("ms")).changed() {
+                        self.settings.set_decay(decay);
+                        let _ = self.settings_sender.send(self.settings.clone());
+                    }
+                });
+                
+                ui.horizontal(|ui| {
+                    ui.label("Sustain:");
+                    let mut sustain = self.settings.get_sustain();
+                    if ui.add(egui::Slider::new(&mut sustain, 0.0..=1.0)).changed() {
+                        self.settings.set_sustain(sustain);
+                        let _ = self.settings_sender.send(self.settings.clone());
+                    }
+                });
+                
+                ui.horizontal(|ui| {
+                    ui.label("Release:");
+                    let mut release = self.settings.get_release();
+                    if ui.add(egui::Slider::new(&mut release, 0..=2000).text("ms")).changed() {
+                        self.settings.set_release(release);
+                        let _ = self.settings_sender.send(self.settings.clone());
+                    }
+                });
+            });
+        });
     }
 }
 
 fn wavetable_sine() -> Vec<f32> {
-    let wave_table_size = 64;
+    let wave_table_size = 2048;
     let mut wave_table: Vec<f32> = Vec::with_capacity(wave_table_size);
     for n in 0..wave_table_size {
         wave_table.push((2.0 * std::f32::consts::PI * n as f32 / wave_table_size as f32).sin());
     }
-    println!("Wave table sine {:?}", wave_table);
-    return wave_table;
+    wave_table
 }
 
 fn wavetable_saw() -> Vec<f32> {
-    let wave_table_size = 64;
+    let wave_table_size = 2048;
     let mut wave_table: Vec<f32> = Vec::with_capacity(wave_table_size);
     for n in 0..wave_table_size {
         wave_table.push(1.0 - 2.0 * (n as f32 / wave_table_size as f32));
     }
-    println!("Wave table saw {:?}", wave_table);
-    return wave_table;
+    wave_table
 }
 
 fn wavetable_square() -> Vec<f32> {
-    let wave_table_size = 64;
+    let wave_table_size = 2048;
     let mut wave_table: Vec<f32> = Vec::with_capacity(wave_table_size);
     for n in 0..wave_table_size {
         let mut val: f32 = 1.0;
@@ -259,58 +719,72 @@ fn wavetable_square() -> Vec<f32> {
         }
         wave_table.push(val);
     }
-    println!("Wave table square {:?}", wave_table);
-    return wave_table;
+    wave_table
 }
 
-fn wavetable_main(wave_table_type: u8, frequency: f32, velocity: f32, shared: Arc<Mutex<f32>>) -> thread::JoinHandle<()> {
-    let note = std::thread::spawn(move ||  {
-        let wave_table: Vec<f32> = match wave_table_type {
-            WAVE_TYPE_SINE => {
-                wavetable_sine()
-            },
-            WAVE_TYPE_SAW => {
-                wavetable_saw()
-            },
-            WAVE_TYPE_SQUARE => {
-                wavetable_square()
-            }
-            _ =>  {
-                wavetable_sine()
-            }
+fn wavetable_main(
+    settings: SynthSettings,
+    frequency: f32,
+    velocity: f32,
+    shared: Arc<Mutex<f32>>,
+    wave_type: u8,
+) -> thread::JoinHandle<()> {
+    let note = std::thread::spawn(move || {
+        let wave_table: Vec<f32> = match wave_type {
+            WAVE_TYPE_SINE => wavetable_sine(),
+            WAVE_TYPE_SAW => wavetable_saw(),
+            WAVE_TYPE_SQUARE => wavetable_square(),
+            _ => wavetable_sine(),
         };
-        let mut oscillator = WavetableOscillator::new(44100, wave_table, Arc::clone(&shared));
+        
+        let mut oscillator = WavetableOscillator::new(SAMPLE_RATE, wave_table, Arc::clone(&shared));
         oscillator.set_frequency(frequency);
         oscillator.set_amplitude(velocity/127.0);
-        // Set attack, delay, sustain, release.
-        oscillator.set_attack(10);
-        oscillator.set_decay(600);
-        oscillator.set_sustain(0.2);
-        oscillator.set_release(800);
+        
+        oscillator.set_attack(settings.get_attack());
+        oscillator.set_decay(settings.get_decay());
+        oscillator.set_sustain(settings.get_sustain());
+        oscillator.set_release(settings.get_release());
+        
+        // Apply filter settings
+        oscillator.set_filter_cutoff(settings.get_filter_cutoff());
+        oscillator.set_filter_resonance(settings.get_filter_resonance());
+        oscillator.set_filter_mode(settings.get_filter_mode());
 
         let (_stream, stream_handle) = OutputStream::try_default().unwrap();
         let _result = stream_handle.play_raw(oscillator.convert_samples());
-        while *shared.lock().unwrap() > 0.0 {}
-        // Allow thread to live until release is done.
-        std::thread::sleep(std::time::Duration::from_millis(RELEASE_MS as u64));
+        
+        // Use a shorter sleep interval for better responsiveness
+        while *shared.lock().unwrap() > 0.0 {
+            thread::sleep(Duration::from_micros(100));
+        }
+        thread::sleep(Duration::from_millis(settings.get_release() as u64));
     });
-    return note;
+    note
 }
 
 fn main() {
-    match run() {
-        Ok(_) => (),
-        Err(err) => println!("Error: {}", err),
-    }
+    let options = eframe::NativeOptions {
+        viewport: egui::ViewportBuilder::default()
+            .with_inner_size([320.0, 240.0]),
+        ..Default::default()
+    };
+    
+    eframe::run_native(
+        "Synthesizer Controls",
+        options,
+        Box::new(|cc| Box::new(SynthUI::new(cc))),
+    )
+    .unwrap();
 }
 
-fn run() -> Result<(), Box<dyn Error>> {
+fn run(settings_receiver: mpsc::Receiver<SynthSettings>) -> Result<(), Box<dyn Error>> {
     let mut input = String::new();
     let mut voice1: HashMap<u8, NoteData> = HashMap::with_capacity(16);
     let mut voice2: HashMap<u8, NoteData> = HashMap::with_capacity(16);
-    //let voices: [usize; 16] = core::array::from_fn(|i| i+1);
+    let mut voice3: HashMap<u8, NoteData> = HashMap::with_capacity(16);
 
-    let mut midi_in= MidiInput::new("midi_read_fx")?;
+    let mut midi_in = MidiInput::new("midi_read_fx")?;
     midi_in.ignore(Ignore::None);
 
     // Get an input port (read from console if multiple are available)
@@ -339,74 +813,93 @@ fn run() -> Result<(), Box<dyn Error>> {
         }
     };
 
-    // Start a quiet wave just to kick start the audio subsystem.
-    let note_length = Arc::new(Mutex::new(1.0));
-    let note = wavetable_main(
-        WAVE_TYPE_SINE,
-        440.0 * 2_f32.powf(69.0/12.0),
-        0.0,
-        Arc::clone(&note_length),
-    );
-    // End the note.
-    *note_length.lock().unwrap() = 0.0;
-
-
     println!("\nOpening connection");
-    // Connection needs to be named to be kept alive.
+    let mut current_settings = SynthSettings::default();
+
     let _conn_in = midi_in.connect(
         in_port,
         "midir-read-input",
-        move |stamp, message, _| {
-            println!("{}: {:?} (len = {})", stamp, message, message.len());
+        move |_stamp, message, _| {
+            // Update settings if new ones are available
+            while let Ok(new_settings) = settings_receiver.try_recv() {
+                current_settings = new_settings;
+            }
+
             match message.len() {
-                2 => {
-                    // Aftertouch?
-                }
                 3 => {
-                    // Regular note data.
                     if message[0] == 0x80 || (message[0] == 0x90 && message[2] == 0) {
-                        // Note off.
-                        let mut note_data = voice1.remove(&message[1]).ok_or("No note found!?").unwrap();
-                        let mut note_shared_vel = note_data.shared.lock().unwrap();
-                        *note_shared_vel = 0.0;
-                        let mut note_data = voice2.remove(&message[1]).ok_or("No note found!?").unwrap();
-                        let mut note_shared_vel = note_data.shared.lock().unwrap();
-                        *note_shared_vel = 0.0;
+                        // Note off - process immediately for responsive release
+                        let mut voice_maps = [&mut voice1, &mut voice2, &mut voice3];
+                        for voice_map in voice_maps.iter_mut() {
+                            if let Some(note_data) = voice_map.remove(&message[1]) {
+                                let mut note_shared_vel = note_data.shared.lock().unwrap();
+                                *note_shared_vel = 0.0;
+                            }
+                        }
                     }
                     else if message[0] == 0x90 {
-                        // Note on w/ velocity.
-                        let shared = Arc::new(Mutex::new(1.0));
-                        let note = wavetable_main(
-                            WAVE_TYPE_SAW,
-                            440.0 * 2_f32.powf((message[1] as f32 - 69.0)/12.0),
-                            message[2] as f32,
-                            Arc::clone(&shared)
-                        );
-                        voice1.insert(message[1], NoteData::new(note, shared));
-                        // Second voice sub-octave.
-                        let shared = Arc::new(Mutex::new(1.0));
-                        let note = wavetable_main(
-                            WAVE_TYPE_SQUARE,
-                            440.0 * 2_f32.powf((message[1] as f32 - 69.0 - 12.0)/12.0),
-                            message[2] as f32,
-                            Arc::clone(&shared)
-                        );
-                        voice2.insert(message[1], NoteData::new(note, shared));
+                        // Helper function to calculate frequency with cents
+                        let calc_freq = |semitones: i32, cents: f32| -> f32 {
+                            let total_semitones = semitones as f32 + (cents / 100.0);
+                            440.0 * 2_f32.powf((message[1] as f32 - 69.0 + total_semitones)/12.0)
+                        };
+
+                        // Create voices if enabled
+                        if current_settings.voice1.is_enabled() {
+                            let shared = Arc::new(Mutex::new(1.0));
+                            let note = wavetable_main(
+                                current_settings.clone(),
+                                calc_freq(
+                                    current_settings.voice1.get_semitones(),
+                                    current_settings.voice1.get_cents()
+                                ),
+                                message[2] as f32 * current_settings.voice1.get_volume(),
+                                Arc::clone(&shared),
+                                current_settings.voice1.get_wave_type()
+                            );
+                            voice1.insert(message[1], NoteData::new(note, shared));
+                        }
+
+                        if current_settings.voice2.is_enabled() {
+                            let shared = Arc::new(Mutex::new(1.0));
+                            let note = wavetable_main(
+                                current_settings.clone(),
+                                calc_freq(
+                                    current_settings.voice2.get_semitones(),
+                                    current_settings.voice2.get_cents()
+                                ),
+                                message[2] as f32 * current_settings.voice2.get_volume(),
+                                Arc::clone(&shared),
+                                current_settings.voice2.get_wave_type()
+                            );
+                            voice2.insert(message[1], NoteData::new(note, shared));
+                        }
+
+                        if current_settings.voice3.is_enabled() {
+                            let shared = Arc::new(Mutex::new(1.0));
+                            let note = wavetable_main(
+                                current_settings.clone(),
+                                calc_freq(
+                                    current_settings.voice3.get_semitones(),
+                                    current_settings.voice3.get_cents()
+                                ),
+                                message[2] as f32 * current_settings.voice3.get_volume(),
+                                Arc::clone(&shared),
+                                current_settings.voice3.get_wave_type()
+                            );
+                            voice3.insert(message[1], NoteData::new(note, shared));
+                        }
                     }
                 }
-                _ => {
-                    // Do nothing?
-                }
+                _ => {}
             }
         },
         (),
     )?;
 
-    //println!("Connection open, reading input from '{}'  (press enter to exit)", in_port_name);
     println!("Connection open (press enter to exit)");
     input.clear();
-    stdin().read_line(&mut input)?; // Wait for enter/key press.
-    
+    stdin().read_line(&mut input)?;
     println!("Closing connection");
     Ok(())
 }


### PR DESCRIPTION
- Fix ownership issue with oscillator.convert_samples()
- Add thread synchronization improvements with efficient sleep loop
- Add amplitude smoothing to reduce audio artifacts
- Remove unused ATTACK_MS and RELEASE_MS constants
- Improve ADSR envelope transitions with smoother curves
- Increase wavetable size for better audio quality

The main fixes address a compilation error where the oscillator was being accessed after being moved, and improve thread handling by using a more efficient sleep loop. Release time is now stored before converting samples to prevent ownership issues.